### PR TITLE
Fix type error in get_name_ea_simple

### DIFF
--- a/LazyIDA.py
+++ b/LazyIDA.py
@@ -37,7 +37,7 @@ def parse_location(loc):
         loc = int(loc, 16)
     except ValueError:
         try:
-            loc = idc.get_name_ea_simple(loc)
+            loc = idc.get_name_ea_simple(loc.encode())
         except:
             return idaapi.BADADDR
     return loc


### PR DESCRIPTION
`Shift-G` won't work when goto a name.
Print the error:
`in method 'get_name_ea', argument 2 of type 'char const *'`
But type of `loc` is `unicode`.