### PR TITLE
If PyQt5.Qt not working, use clipboard instead

### DIFF
--- a/LazyIDA.py
+++ b/LazyIDA.py
@@ -5,7 +5,10 @@ import idaapi
 import idautils
 import idc
 
-from PyQt5.Qt import QApplication
+try:
+    from PyQt5.Qt import QApplication
+except:
+    import clipboard
 
 ACTION_CONVERT = ["lazyida:convert%d" % i for i in range(10)]
 ACTION_SCANVUL = "lazyida:scanvul"
@@ -27,10 +30,16 @@ ARCH = 0
 BITS = 0
 
 def copy_to_clip(data):
-    QApplication.clipboard().setText(data)
+    try:
+        QApplication.clipboard().setText(data)
+    except:
+        clipboard.copy(data)
 
 def clip_text():
-    return QApplication.clipboard().text()
+    try:
+        return QApplication.clipboard().text()
+    except:
+        return clipboard.paste()
 
 def parse_location(loc):
     try:


### PR DESCRIPTION
**Environment:**
Python 3.9
IdaPro 7.5

**Description:**
When the plugin loading, it gives the error:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name 'QApplication' from 'PyQt5.Qt'
```

Even I tried to use `from PyQt5.QtWidgets import QApplication`, but I got the following error:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: DLL load failed while importing sip: The specified module could not be found.
```

After some searching, I found the [issue](https://github.com/igogo-x86/HexRaysPyTools/issues/48), while the solution of the issue is not working on python3.9, either.

As a result, I use clipboard to copy and paste the name and address instead of QApplication, so it will import and use clipboard if  there is any error while using QApplication.