### PR TITLE
Replace deprecated attribute

### DIFF
--- a/LazyIDA.py
+++ b/LazyIDA.py
@@ -91,7 +91,11 @@ class hotkey_action_handler_t(idaapi.action_handler_t):
         return 1
 
     def update(self, ctx):
-        if ctx.form_type in (idaapi.BWN_DISASM, idaapi.BWN_DUMP):
+        if idaapi.IDA_SDK_VERSION >= 770:
+            target_attr = "widget_type"
+        else:
+            target_attr = "form_type"
+        if ctx.__getattr__(target_attr) in (idaapi.BWN_DISASM, idaapi.BWN_DUMP):
             return idaapi.AST_ENABLE_FOR_WIDGET
         else:
             return idaapi.AST_DISABLE_FOR_WIDGET


### PR DESCRIPTION
## Summary

This PR replaces the deprecated attribute `form_type` to `widget_type` to prevent future compatibility issues starting from 7.7.