### PR TITLE
correct size

### DIFF
--- a/LazyIDA.py
+++ b/LazyIDA.py
@@ -114,7 +114,7 @@ class menu_action_handler_t(idaapi.action_handler_t):
             t0, t1, view = idaapi.twinpos_t(), idaapi.twinpos_t(), idaapi.get_current_viewer()
             if idaapi.read_selection(view, t0, t1):
                 start, end = t0.place(view).toea(), t1.place(view).toea()
-                size = end - start
+                size = end - start + 1
             elif idc.get_item_size(idc.get_screen_ea()) > 1:
                 start = idc.get_screen_ea()
                 size = idc.get_item_size(start)


### PR DESCRIPTION
The size `end - start` will cause the range of the selection to be wrong, since the correct size is `end - start + 1` instead.

Below is the result of `end - start + 1`.
![image](https://user-images.githubusercontent.com/33378686/155707872-b8c20388-3332-4afc-9a3d-228814176900.png)
