### PR TITLE
add FO copy/goto commands + fixes

### DIFF
--- a/LazyIDA.py
+++ b/LazyIDA.py
@@ -10,14 +10,18 @@ from PyQt5.Qt import QApplication
 ACTION_CONVERT = ["lazyida:convert%d" % i for i in range(10)]
 ACTION_SCANVUL = "lazyida:scanvul"
 ACTION_COPYEA = "lazyida:copyea"
-ACTION_GOTOCLIP = "lazyida:gotoclip"
+ACTION_COPYFO = "lazyida:copyfo"
+ACTION_GOTOCLIPEA = "lazyida:gotoclipea"
+ACTION_GOTOCLIPFO = "lazyida:gotoclipfo"
 ACTION_XORDATA = "lazyida:xordata"
 ACTION_FILLNOP = "lazyida:fillnop"
 
 ACTION_HX_REMOVERETTYPE = "lazyida:hx_removerettype"
 ACTION_HX_COPYEA = "lazyida:hx_copyea"
+ACTION_HX_COPYFO = "lazyida:hx_copyfo"
 ACTION_HX_COPYNAME = "lazyida:hx_copyname"
-ACTION_HX_GOTOCLIP = "lazyida:hx_gotoclip"
+ACTION_HX_GOTOCLIPEA = "lazyida:hx_gotoclipea"
+ACTION_HX_GOTOCLIPFO = "lazyida:hx_gotoclipfo"
 
 u16 = lambda x: unpack("<H", x)[0]
 u32 = lambda x: unpack("<I", x)[0]
@@ -32,15 +36,21 @@ def copy_to_clip(data):
 def clip_text():
     return QApplication.clipboard().text()
 
-def parse_location(loc):
+def parse_location(loc, is_fo=False):
+    is_named = False
+    ascii_text = ""
     try:
         loc = int(loc, 16)
+        if is_fo:
+            loc = idaapi.get_fileregion_ea(loc)
     except ValueError:
         try:
-            loc = idc.get_name_ea_simple(loc.encode().strip())
+            ascii_text = loc.encode(encoding="ascii",errors="replace").decode(encoding="ascii").strip()
+            loc = idc.get_name_ea_simple(ascii_text)
+            is_named = True
         except:
             return idaapi.BADADDR
-    return loc
+    return loc, is_named, ascii_text
 
 class VulnChoose(idaapi.Choose):
     """
@@ -82,11 +92,29 @@ class hotkey_action_handler_t(idaapi.action_handler_t):
             ea = idc.get_screen_ea()
             if ea != idaapi.BADADDR:
                 copy_to_clip("0x%X" % ea)
-                print("Address 0x%X has been copied to clipboard" % ea)
-        elif self.action == ACTION_GOTOCLIP:
-            loc = parse_location(clip_text())
+                print("Address 0x%X (EA) has been copied to clipboard" % ea)
+        elif self.action == ACTION_COPYFO:
+            ea = idc.get_screen_ea()
+            if ea != idaapi.BADADDR:
+            	fo = idaapi.get_fileregion_offset(ea)
+            	if fo != idaapi.BADADDR:
+                    copy_to_clip("0x%X" % fo)
+                    print("Address 0x%X (FO) has been copied to clipboard" % fo)
+        elif self.action == ACTION_GOTOCLIPEA:
+            loc, is_named, name = parse_location(clip_text(), False)
             if loc != idaapi.BADADDR:
-                print("Goto location 0x%x" % loc)
+                if is_named:
+                    print("Goto named location '%s' 0x%X" % (name, loc))
+                else:
+                    print("Goto location 0x%X (EA)" % loc)
+                idc.jumpto(loc)
+        elif self.action == ACTION_GOTOCLIPFO:
+            loc, is_named, name = parse_location(clip_text(), True)
+            if loc != idaapi.BADADDR:
+                if is_named:
+                    print("Goto named location '%s' 0x%X" % (name, loc))
+                else:
+                    print("Goto location 0x%X (FO)" % idaapi.get_fileregion_offset(loc))
                 idc.jumpto(loc)
         return 1
 
@@ -119,7 +147,7 @@ class menu_action_handler_t(idaapi.action_handler_t):
 
     def activate(self, ctx):
         if self.action in ACTION_CONVERT:
-            # convert
+            # convert (dump as)
             t0, t1, view = idaapi.twinpos_t(), idaapi.twinpos_t(), idaapi.get_current_viewer()
             if idaapi.read_selection(view, t0, t1):
                 start, end = t0.place(view).toea(), t1.place(view).toea()
@@ -338,17 +366,36 @@ class hexrays_action_handler_t(idaapi.action_handler_t):
             ea = idaapi.get_screen_ea()
             if ea != idaapi.BADADDR:
                 copy_to_clip("0x%X" % ea)
-                print("Address 0x%X has been copied to clipboard" % ea)
+                print("Address 0x%X (EA) has been copied to clipboard" % ea)
+        elif self.action == ACTION_HX_COPYFO:
+            ea = idaapi.get_screen_ea()
+            if ea != idaapi.BADADDR:
+                fo = idaapi.get_fileregion_offset(ea)
+                if fo != idaapi.BADADDR:
+                    copy_to_clip("0x%X" % fo)
+                    print("Address 0x%X (FO) has been copied to clipboard" % fo)
         elif self.action == ACTION_HX_COPYNAME:
             highlight = idaapi.get_highlight(idaapi.get_current_viewer()) 
             name = highlight[0] if highlight else None
             if name:
                 copy_to_clip(name)
-                print("%s has been copied to clipboard" % name)
-        elif self.action == ACTION_HX_GOTOCLIP:
-            loc = parse_location(clip_text())
-            print("Goto location 0x%x" % loc)
-            idc.jumpto(loc)
+                print("'%s' has been copied to clipboard" % name)
+        elif self.action == ACTION_HX_GOTOCLIPEA:
+            loc, is_named, name = parse_location(clip_text(), False)
+            if loc != idaapi.BADADDR:
+                if is_named:
+                    print("Goto named location '%s' 0x%X" % (name, loc))
+                else:
+                    print("Goto location 0x%X (EA)" % loc)
+                idc.jumpto(loc)
+        elif self.action == ACTION_HX_GOTOCLIPFO:
+            loc, is_named, name = parse_location(clip_text(), True)
+            if loc != idaapi.BADADDR:
+                if is_named:
+                    print("Goto named location '%s' 0x%X" % (name, loc))
+                else:
+                    print("Goto location 0x%X (FO)" % idaapi.get_fileregion_offset(ea))
+                idc.jumpto(loc)
         else:
             return 0
 
@@ -431,7 +478,7 @@ class UI_Hook(idaapi.UI_Hooks):
                 idaapi.attach_action_to_popup(form, popup, ACTION_XORDATA, None)
                 idaapi.attach_action_to_popup(form, popup, ACTION_FILLNOP, None)
                 for action in ACTION_CONVERT:
-                    idaapi.attach_action_to_popup(form, popup, action, "Convert/")
+                    idaapi.attach_action_to_popup(form, popup, action, "Dump/")
 
         if form_type == idaapi.BWN_DISASM and (ARCH, BITS) in [(idaapi.PLFM_386, 32),
                                                                (idaapi.PLFM_386, 64),
@@ -500,20 +547,20 @@ class LazyIDA_t(idaapi.plugin_t):
             else:
                 BITS = 16
 
-        print("LazyIDA (v1.0.0.3) plugin has been loaded.")
+        print("LazyIDA (v1.0.0.4) plugin has been loaded.")
 
         # Register menu actions
         menu_actions = (
-            idaapi.action_desc_t(ACTION_CONVERT[0], "Convert to string", menu_action_handler_t(ACTION_CONVERT[0]), None, None, 80),
-            idaapi.action_desc_t(ACTION_CONVERT[1], "Convert to hex string", menu_action_handler_t(ACTION_CONVERT[1]), None, None, 8),
-            idaapi.action_desc_t(ACTION_CONVERT[2], "Convert to C/C++ array (BYTE)", menu_action_handler_t(ACTION_CONVERT[2]), None, None, 38),
-            idaapi.action_desc_t(ACTION_CONVERT[3], "Convert to C/C++ array (WORD)", menu_action_handler_t(ACTION_CONVERT[3]), None, None, 38),
-            idaapi.action_desc_t(ACTION_CONVERT[4], "Convert to C/C++ array (DWORD)", menu_action_handler_t(ACTION_CONVERT[4]), None, None, 38),
-            idaapi.action_desc_t(ACTION_CONVERT[5], "Convert to C/C++ array (QWORD)", menu_action_handler_t(ACTION_CONVERT[5]), None, None, 38),
-            idaapi.action_desc_t(ACTION_CONVERT[6], "Convert to python list (BYTE)", menu_action_handler_t(ACTION_CONVERT[6]), None, None, 201),
-            idaapi.action_desc_t(ACTION_CONVERT[7], "Convert to python list (WORD)", menu_action_handler_t(ACTION_CONVERT[7]), None, None, 201),
-            idaapi.action_desc_t(ACTION_CONVERT[8], "Convert to python list (DWORD)", menu_action_handler_t(ACTION_CONVERT[8]), None, None, 201),
-            idaapi.action_desc_t(ACTION_CONVERT[9], "Convert to python list (QWORD)", menu_action_handler_t(ACTION_CONVERT[9]), None, None, 201),
+            idaapi.action_desc_t(ACTION_CONVERT[0], "Dump as string", menu_action_handler_t(ACTION_CONVERT[0]), None, None, 80),
+            idaapi.action_desc_t(ACTION_CONVERT[1], "Dump as hex string", menu_action_handler_t(ACTION_CONVERT[1]), None, None, 8),
+            idaapi.action_desc_t(ACTION_CONVERT[2], "Dump as C/C++ array (BYTE)", menu_action_handler_t(ACTION_CONVERT[2]), None, None, 38),
+            idaapi.action_desc_t(ACTION_CONVERT[3], "Dump as C/C++ array (WORD)", menu_action_handler_t(ACTION_CONVERT[3]), None, None, 38),
+            idaapi.action_desc_t(ACTION_CONVERT[4], "Dump as C/C++ array (DWORD)", menu_action_handler_t(ACTION_CONVERT[4]), None, None, 38),
+            idaapi.action_desc_t(ACTION_CONVERT[5], "Dump as C/C++ array (QWORD)", menu_action_handler_t(ACTION_CONVERT[5]), None, None, 38),
+            idaapi.action_desc_t(ACTION_CONVERT[6], "Dump as python list (BYTE)", menu_action_handler_t(ACTION_CONVERT[6]), None, None, 201),
+            idaapi.action_desc_t(ACTION_CONVERT[7], "Dump as python list (WORD)", menu_action_handler_t(ACTION_CONVERT[7]), None, None, 201),
+            idaapi.action_desc_t(ACTION_CONVERT[8], "Dump as python list (DWORD)", menu_action_handler_t(ACTION_CONVERT[8]), None, None, 201),
+            idaapi.action_desc_t(ACTION_CONVERT[9], "Dump as python list (QWORD)", menu_action_handler_t(ACTION_CONVERT[9]), None, None, 201),
             idaapi.action_desc_t(ACTION_XORDATA, "Get xored data", menu_action_handler_t(ACTION_XORDATA), None, None, 9),
             idaapi.action_desc_t(ACTION_FILLNOP, "Fill with NOPs", menu_action_handler_t(ACTION_FILLNOP), None, None, 9),
             idaapi.action_desc_t(ACTION_SCANVUL, "Scan format string vulnerabilities", menu_action_handler_t(ACTION_SCANVUL), None, None, 160),
@@ -525,7 +572,9 @@ class LazyIDA_t(idaapi.plugin_t):
         # Register hotkey actions
         hotkey_actions = (
             idaapi.action_desc_t(ACTION_COPYEA, "Copy EA", hotkey_action_handler_t(ACTION_COPYEA), "w", "Copy current EA", 0),
-            idaapi.action_desc_t(ACTION_GOTOCLIP, "Goto clip EA", hotkey_action_handler_t(ACTION_GOTOCLIP), "Shift-G", "Goto clipboard EA", 0),
+            idaapi.action_desc_t(ACTION_COPYFO, "Copy FO", hotkey_action_handler_t(ACTION_COPYFO), "Shift-W", "Copy current FO", 0),
+            idaapi.action_desc_t(ACTION_GOTOCLIPEA, "Goto clipboard EA", hotkey_action_handler_t(ACTION_GOTOCLIPEA), "Shift-G"),
+            idaapi.action_desc_t(ACTION_GOTOCLIPFO, "Goto clipboard FO", hotkey_action_handler_t(ACTION_GOTOCLIPFO), "Ctrl-Shift-G"),
         )
         for action in hotkey_actions:
             idaapi.register_action(action)
@@ -542,14 +591,16 @@ class LazyIDA_t(idaapi.plugin_t):
             addon.name = "LazyIDA"
             addon.producer = "Lays"
             addon.url = "https://github.com/L4ys/LazyIDA"
-            addon.version = "1.0.0.3"
+            addon.version = "1.0.0.4"
             idaapi.register_addon(addon)
 
             hx_actions = (
                 idaapi.action_desc_t(ACTION_HX_REMOVERETTYPE, "Remove return type", hexrays_action_handler_t(ACTION_HX_REMOVERETTYPE), "v"),
-                idaapi.action_desc_t(ACTION_HX_COPYEA, "Copy ea", hexrays_action_handler_t(ACTION_HX_COPYEA), "w"),
+                idaapi.action_desc_t(ACTION_HX_COPYEA, "Copy EA", hexrays_action_handler_t(ACTION_HX_COPYEA), "w", "Copy current EA", 0),
+                idaapi.action_desc_t(ACTION_HX_COPYFO, "Copy FO", hexrays_action_handler_t(ACTION_HX_COPYFO), "Shift-W", "Copy current FO", 0),
+                idaapi.action_desc_t(ACTION_HX_GOTOCLIPEA, "Goto clipboard EA", hexrays_action_handler_t(ACTION_HX_GOTOCLIPEA), "Shift-G"),
+                idaapi.action_desc_t(ACTION_HX_GOTOCLIPFO, "Goto clipboard FO", hexrays_action_handler_t(ACTION_HX_GOTOCLIPFO), "Ctrl-Shift-G"),
                 idaapi.action_desc_t(ACTION_HX_COPYNAME, "Copy name", hexrays_action_handler_t(ACTION_HX_COPYNAME), "c"),
-                idaapi.action_desc_t(ACTION_HX_GOTOCLIP, "Goto clipboard ea", hexrays_action_handler_t(ACTION_HX_GOTOCLIP), "Shift-G"),
             )
             for action in hx_actions:
                 idaapi.register_action(action)


### PR DESCRIPTION
- Add "Copy FO" command (Shift-W)
- Add "Goto clipboard FO" command (Ctrl-Shift-G)
- Fix parse_location, going to named functions works again
- Normalize IDAView / HexRaysView command descriptions
- Fix HexRaysView missed badaddr check
- Print in output whether you are going to EA, FO or named function
- Rename "Convert to" -> "Dump as" for more accurate description
- Bump version number to 1.0.0.4
